### PR TITLE
Added tests for group endpoints

### DIFF
--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,339 @@
+"""
+Contract-level tests for the /api/auth endpoint
+"""
+
+import pytest
+from httpx import AsyncClient
+
+
+# Tests for POST /api/auth/register
+@pytest.mark.asyncio
+async def test_register_new_user_empty_username_error(client: AsyncClient):
+    """Test that POST /api/auth/register requires a username"""
+    user_data = {
+        "username": "",
+        "email": "abc@example.com",
+        "password": "password",
+        "role": "user",
+    }
+    response = await client.post("/api/auth/register", json=user_data)
+    """Empty username rejected"""
+    assert response.status_code == 400
+    assert "Username cannot be empty" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_register_new_user_empty_email_error(client: AsyncClient):
+    """Test that POST /api/auth/register requires an email"""
+    user_data = {
+        "username": "username",
+        "email": "",
+        "password": "password",
+        "role": "user",
+    }
+    response = await client.post("/api/auth/register", json=user_data)
+    """Empty email rejected"""
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_register_new_user_empty_password_error(client: AsyncClient):
+    """Test that POST /api/auth/register requires a password"""
+    user_data = {
+        "username": "username",
+        "email": "abc@example.com",
+        "password": "",
+        "role": "user",
+    }
+    response = await client.post("/api/auth/register", json=user_data)
+    """Empty password rejected"""
+    assert response.status_code == 400
+    assert "Password cannot be empty" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_register_new_user_success(client: AsyncClient):
+    """Test that POST /api/auth/register creates a new user
+    given the appropriate inputs"""
+    user_data = {
+        "username": "username",
+        "email": "abc@example.com",
+        "password": "password",
+        "role": "user",
+    }
+    response = await client.post("/api/auth/register", json=user_data)
+    """Created new user"""
+    assert response.status_code == 201
+    data = response.json()
+    assert data["username"] == "username"
+    assert data["email"] == "abc@example.com"
+    assert data["role"]["name"] == "user"
+    assert "password" not in data  # Password should not be in response
+
+
+@pytest.mark.asyncio
+async def test_register_new_user_with_admin_role(client: AsyncClient, auth_headers):
+    """Test that POST /api/auth/register creates a new admin
+    given the appropriate inputs"""
+    user_data = {
+        "username": "username",
+        "email": "abc@example.com",
+        "password": "password",
+        "role": "admin",
+    }
+    response = await client.post(
+        "/api/auth/register", json=user_data, headers=auth_headers
+    )
+    """Created new admin user"""
+    assert response.status_code == 201
+    data = response.json()
+    assert data["username"] == "username"
+    assert data["email"] == "abc@example.com"
+    assert data["role"]["name"] == "admin"
+    assert "password" not in data  # Password should not be in response
+
+
+@pytest.mark.asyncio
+async def test_register_new_user_with_invalid_role_error(client: AsyncClient):
+    """Test that POST /api/auth/register creates a new admin
+    given the appropriate inputs"""
+    user_data = {
+        "username": "username",
+        "email": "abc@example.com",
+        "password": "password",
+        "role": "sillysalmon",
+    }
+    response = await client.post("/api/auth/register", json=user_data)
+    """Role name does not pass validaton"""
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_register_new_user_with_duplicate_username_error(
+    client: AsyncClient, auth_headers
+):
+    """Test that POST /api/auth/register returns error for duplicate username"""
+    user_data = {
+        "username": "duplicate",
+        "email": "first@example.com",
+        "password": "password123",
+        "role": "user",
+    }
+    # Create first user
+    create_response = await client.post(
+        "/api/auth/register", json=user_data, headers=auth_headers
+    )
+    assert create_response.status_code == 201
+    first_user_id = create_response.json()["id"]
+
+    # Verify the first user was actually created
+    get_response = await client.get(f"/api/users/{first_user_id}", headers=auth_headers)
+    assert get_response.status_code == 200
+    assert get_response.json()["username"] == "duplicate"
+
+    # Try to create duplicate username (different email)
+    user_data["email"] = "second@example.com"
+    response = await client.post(
+        "/api/auth/register", json=user_data, headers=auth_headers
+    )
+    assert response.status_code == 400
+    assert "username already registered" in response.json()["detail"].lower()
+
+    # Verify the first user still exists and wasn't affected
+    get_response = await client.get(f"/api/users/{first_user_id}", headers=auth_headers)
+    assert get_response.status_code == 200
+    assert (
+        get_response.json()["email"] == "first@example.com"
+    )  # Original email unchanged
+
+
+@pytest.mark.asyncio
+async def test_register_new_user_with_duplicate_email_error(
+    client: AsyncClient, auth_headers
+):
+    """Test that POST /api/auth/register returns error for duplicate email"""
+    user_data = {
+        "username": "username",
+        "email": "duplicate@example.com",
+        "password": "password123",
+        "role": "user",
+    }
+    # Create first user
+    create_response = await client.post(
+        "/api/auth/register", json=user_data, headers=auth_headers
+    )
+    assert create_response.status_code == 201
+    first_user_id = create_response.json()["id"]
+
+    # Verify the first user was actually created
+    get_response = await client.get(f"/api/users/{first_user_id}", headers=auth_headers)
+    assert get_response.status_code == 200
+    assert get_response.json()["username"] == "username"
+
+    # Try to create duplicate email (different username)
+    user_data["username"] = "username2"
+    response = await client.post(
+        "/api/auth/register", json=user_data, headers=auth_headers
+    )
+    assert response.status_code == 400
+    assert "email already registered" in response.json()["detail"].lower()
+
+    # Verify the first user still exists and wasn't affected
+    get_response = await client.get(f"/api/users/{first_user_id}", headers=auth_headers)
+    assert get_response.status_code == 200
+    assert get_response.json()["username"] == "username"  # Original username unchanged
+
+
+# Tests for POST /api/auth/login
+@pytest.mark.asyncio
+async def test_login_with_proper_credentials_returns_access_token(
+    client: AsyncClient, auth_headers
+):
+    """Test that POST /api/auth/login successfully logs in
+    with proper username/password"""
+    user_data = {
+        "username": "username",
+        "email": "user@example.com",
+        "password": "password",
+    }
+    # Create user
+    create_response = await client.post("/api/auth/register", json=user_data)
+    assert create_response.status_code == 201
+    user_id = create_response.json()["id"]
+
+    # Verify the first user was actually created
+    get_response = await client.get(f"/api/users/{user_id}", headers=auth_headers)
+    assert get_response.status_code == 200
+    assert get_response.json()["username"] == "username"
+
+    user_data = {"username": "username", "password": "password"}
+    # Verify the login is successful
+    response = await client.post("/api/auth/login", json=user_data)
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_login_with_empty_username_returns_error(client: AsyncClient):
+    """Test that POST /api/auth/login returns 401 Unauthorized
+    when given an empty username"""
+    user_data = {"username": "", "password": "password"}
+    response = await client.post("/api/auth/login", json=user_data)
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_login_with_empty_password_returns_error(client: AsyncClient):
+    """Test that POST /api/auth/login returns 401 Unauthorized
+    when given an empty password"""
+    user_data = {"username": "username", "password": ""}
+    response = await client.post("/api/auth/login", json=user_data)
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_login_with_incorrect_password_returns_error(client: AsyncClient):
+    """Test that POST /api/auth/login returns 401 Unauthorized
+    when given an incorrect password"""
+    user_data = {
+        "username": "username",
+        "email": "user@example.com",
+        "password": "password",
+    }
+    # Create user
+    create_response = await client.post("/api/auth/register", json=user_data)
+    assert create_response.status_code == 201
+
+    user_data = {"username": "username", "password": "notpassword"}
+    response = await client.post("/api/auth/login", json=user_data)
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_login_with_disabled_acc_returns_error(client: AsyncClient, auth_headers):
+    """Test that POST /api/auth/login returns 403 Forbidden
+    when logging into a disabled account"""
+    user_data = {
+        "username": "username",
+        "email": "user@example.com",
+        "password": "password",
+    }
+    # Create user
+    create_response = await client.post("/api/auth/register", json=user_data)
+    assert create_response.status_code == 201
+    user_id = create_response.json()["id"]
+
+    # Deactivate account
+    status_data = {"user_id": user_id, "is_active": False}
+    get_response = await client.patch(
+        f"/api/users/{user_id}/status", headers=auth_headers, json=status_data
+    )
+    assert get_response.status_code == 200
+    assert get_response.json()["is_active"] == 0
+
+    # Attempt to log into deactivated account
+    user_data = {"username": "username", "password": "password"}
+    response = await client.post("/api/auth/login", json=user_data)
+    assert response.status_code == 403
+    # Returns 403 Forbidden
+
+
+# Tests for GET /api/auth/me
+@pytest.mark.asyncio
+async def test_get_current_info_returns_user_info(
+    client: AsyncClient, user_auth_headers
+):
+    """Test that GET /api/auth/me returns proper user info
+    when given bearer token authentication"""
+
+    # Get current user data
+    response = await client.get("/api/auth/me", headers=user_auth_headers)
+    assert response.status_code == 200
+
+    # Check that the data retrieved is what it should be
+    retrieved_data = response.json()
+    assert retrieved_data["username"] == "regular_user"
+    assert retrieved_data["email"] == "user@test.com"
+    assert retrieved_data["role"]["id"] == 1
+    assert retrieved_data["is_active"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_current_info_requires_bearer_token_authentication(
+    client: AsyncClient,
+):
+    """Test that GET /api/auth/me returns 401 Unauthorized
+    when not given bearer token authentication"""
+    response = await client.get("/api/auth/me")
+    assert response.status_code == 401
+
+
+# Tests for GET /api/auth/users
+@pytest.mark.asyncio
+async def test_get_users_gets_users_given_admin_role(client: AsyncClient, auth_headers):
+    """Test that GET /api/auth/users returns a list of users when authenticatied"""
+
+    response = await client.get("/api/auth/users", headers=auth_headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+
+    # Verify the list contains at least the admin user we created
+    assert len(data) >= 1
+    # Verify each item in the list has the expected user structure
+    for user in data:
+        assert "id" in user
+        assert "username" in user
+        assert "email" in user
+        assert "role" in user
+        assert "password" not in user  # Password should never be in response
+
+    # Verify the admin user is in the list
+    admin_usernames = [user["username"] for user in data]
+    assert "admin" in admin_usernames
+
+
+@pytest.mark.asyncio
+async def test_get_all_users_requires_auth(client: AsyncClient):
+    """Test that GET /api/auth/users requires authentication"""
+    response = await client.get("/api/auth/users")
+    assert response.status_code == 401

--- a/pre-push.md
+++ b/pre-push.md
@@ -1,12 +1,15 @@
 ## What to do before you push
 ### Remove All Debug Code and Make sure the Code Runs
 Make sure console logs/print statements are removed. If you have blocks of commented code, delete it (if reasonable) to keep the codebase clean.
-### Run All Linters:
-Backend: `docker exec -it tma_backend bash scripts/fix.sh`
+### Run All Linters AND CHECKS:
+(The checks pick up on things you'll have to manually do)
+Backend: `docker exec -it tma_backend bash scripts/fix.sh` and
+`docker exec -it tma_backend bash scripts/check.sh`
 
-Frontend: `docker exec -it tma_frontend npm run fix`
+Frontend: `docker exec -it tma_frontend npm run fix` and 
+`docker exec -it tma_frontend npm run check`
 
-Mobile: `cd mobile` then `npm run fix`
+Mobile: `cd mobile` then `npm run fix` and `npm run check`
 ### Run All Tests:
 -*Feel free to remove the `:verbose`*-
 

--- a/team-working-agreement.md
+++ b/team-working-agreement.md
@@ -28,6 +28,7 @@ In person, in the 3rd floor of RRO.
 ## Work Distribution
 - How will we divide work? (volunteer? rotate? assign?)
 Collaborative assignment. Identify what needs to get done and work together to divide it logically and assign/volunteer takers.
+    - Once work is split up, one member is responsible for sending a Discord message summarizing the divison of work. After this, the person responsible for the work should make any related Issues on GitHub, and definetly needs to make a Pull Request detailing what they've done regarding their task. That person must also assign at least one person to review the PR. It is likely this person will be pre-determined during the Discord messaging stage, but if they are not. The group should hold a quick discussion (in person or over text) to determine who is available to look over it. 
 - How will we ensure everyone contributes?
 Expect contribution, but be ready to address people by name who are not meeting the predetermined expectations.
 - What if someone is struggling?
@@ -36,18 +37,31 @@ If you are struggling PLEASE reach out as quickly and openly as possible, it is 
 ## Code Review
 - Who reviews PRs? (everyone? specific people?)
 Everyone, rotate per assignment. This rotation should be factored in during work distribution, and should take people's busyness into consideration. When making your PR assign that designated person. 
+    - Even if you have no suggestions for improvement on a PR, still leave a comment on it. This reaffirms that you have spent time truly reviewing the code, and haven't just blindly approved it for merging.
 - How quickly should reviews happen? (within 24 hours?)
 Within 24 hours. Communicate if you can’t do it, you are responsible for finding someone else who can.
 - What makes a good review? (constructive, specific, kind)
 See Dr. Sarah’s recourses on that.
 
 ## Conflict Resolution
-- What if we disagree?
-Fight in the parking lot. Have a mature conversation, over text if that makes you feel more comfortable.
-- What if someone isn't contributing?
-Involve teachers, after trying to handle the conflict within the group.
-- How do we give feedback?
-PRs, using the text channel. Be sure to use your please’s and thank you’s! 
+- **Disagreements About Implementation:** 
+  - Discuss in the Discord chanel and/or at team meetings, give each perspective time to list why they think their implementation would fit the project better. Then hold a discussion where everyone open-mindedly considers the pros and cons of each implementation. Be willing to concede your side if logic presents a better option. This project isn't about who comes up with *more* of the solutions, but which solutions are *best*.
+  - If no consensus is met, vote (majority rules)
+  - Escalate to instructor if needed, be ready to provide a small written analysis about the implementation you are suggesting.
+- **Interpersonal Disagreements**
+    - Such disagreements should be handled privately. Please try not to bring issues like this into the Discord chanel or meetings, unless the disagreement is causing a safety concern or making one member of the group uncomfortable to be around the other. 
+    - Try to come to a mutual understanding, even if that understanding is that the two parties won't see eye-to-eye on the topic. Remember that this team project will only last for a few weeks.
+    - In extreme cases, involve an instructor.
+- **Non-contribution:**
+  - The team should take great care to clearly define the individual expectations for each person. If someone is not meeting these expectations by the agreed upon deadline, or seems to be significantly falling behind prior to the deadline, check in with them privately first (maybe they're struggling?).
+    - If they are struggling, than the team should be willing to re organize tasks / expectations in a way that is appropriate.
+  - If the behavior continues, especially without decent communication from the team member in question, discuss in team meeting.
+  - Finally, escalate to instructor if needed
+- **Feedback:** 
+  - Give feedback directly and kindly. Try to focus not only on things for improvement, but also things that the other person did well. Acknowledging these things can help the team identify good habits and qualities that everyone hone in on, as well has negative practices that can be improved upon.
+  - Focus on behavior, not personality
+  - Use "I" statements ("I feel..." not "You always...")
+
 
 ## Learning & Growth
 - How will we help each other learn?


### PR DESCRIPTION
## What Changed
Adds tests for group endpoints:
- GET /api/groups
- GET /api/groups/{id}
- POST /api/groups
- PATCH /api/groups/{id}
- DELETE /api/groups/{id}

I also added to conftest.py:
- `test_group_inaccessible_by_regular`: creates a group for testing that is accessible by admin and managers but not regular users
- `test_group_accessible_by_regular`: creates a group for testing that regular user is in so it is accessible by regular user

## Why
This PR addresses the HW1 requirement to write contract-level tests for 3 endpoints. 

## How to Test:
1. Run `pytest tests/test_auth.py` to see new tests
2. Verify all tests pass

## Related
- Closes #4  
- Closes #5 
- Closes #6 
- Closes #7 
- Closes #8

Here is a list of things I tested for:
## GET /api/groups
- Admin and managers should see all groups
- Regular Users should only see the groups they are in

## GET /api/groups/{id}
- Admin and managers have access to all groups
- Regular users only have access to see the groups they are in
- Valid ID must be used

## POST /api/groups
- Admin and managers can create a group
- Regular users can not create a group 
- Creator of the group become its owner
- Name field is required
- Name field should not be an empty string
- Name field must be a string
- Description field is optional
- Description field must be a string if included

## PATCH /api/groups{id}
- Admin and managers can update a group
- Regular users can not update a group
- Name and Description fields are optional
- Name can not be changed to an empty string
- Valid ID must be used

## DELETE /api/groups/{id}
- Admin and managers can delete a group
- Ensure group is actually deleted
- Regular users can not delete a group
- Valid ID must be used