### PR TITLE
Added all modles for current design to backend/models.

### DIFF
--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -2,6 +2,14 @@
 from .base import Base  # noqa: F401
 from .course import Course  # noqa: F401
 from .course_group import CourseGroup  # noqa: F401
-from .group import Group, UserGroup  # noqa: F401
+from .course_module import CourseModule  # noqa: F401
+from .group import Group  # noqa: F401
+from .module import Module  # noqa: F401
+from .module_post import ModulePost  # noqa: F401
+from .post import Post  # noqa: F401
 from .role import Role  # noqa: F401
 from .user import User  # noqa: F401
+from .user_course import UserCourse  # noqa: F401
+from .user_group import UserGroup  # noqa: F401
+from .user_modules import UserModule  # noqa: F401
+from .user_posts import UserPost  # noqa: F401

--- a/backend/models/course_group.py
+++ b/backend/models/course_group.py
@@ -35,7 +35,7 @@ class CourseGroup(Base):
     group_id = Column(
         Integer, ForeignKey("groups.id", ondelete="CASCADE"), nullable=False, index=True
     )
-    ordering = Column(Integer, nullable=False, default=0)
+    ordering = Column(Integer, nullable=False, default=0, index=True)
     date_assigned = Column(Date, nullable=False, default=date.today)
     created_at = Column(TIMESTAMP, default=datetime.utcnow, nullable=False)
 

--- a/backend/models/course_module.py
+++ b/backend/models/course_module.py
@@ -1,0 +1,46 @@
+"""
+CourseModule model for many-to-many relationship between courses and modules
+"""
+
+from datetime import date, datetime
+
+from sqlalchemy import TIMESTAMP, Column, Date, ForeignKey, Integer, UniqueConstraint
+from sqlalchemy.orm import relationship
+
+from .base import Base
+
+
+class CourseModule(Base):
+    """
+    Many-to-many relationship between courses and modules.
+    Represents the modules inclulded in a course.
+    """
+
+    __tablename__ = "course_modules"
+
+    id = Column(Integer, primary_key=True, index=True)
+    course_id = Column(
+        Integer,
+        ForeignKey("courses.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    module_id = Column(
+        Integer,
+        ForeignKey("modules.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    ordering = Column(Integer, nullable=False, default=0, index=True)
+    date_assigned = Column(Date, nullable=False, default=date.today)  # likely metadata
+    created_at = Column(TIMESTAMP, default=datetime.utcnow, nullable=False)
+
+    # Relationships
+    course = relationship("Course", backref="course_modules")
+    module = relationship("Module", backref="course_modules")
+
+    # Ensure a module can only be assigned to a course once
+    # (The same module won't be in the same course twice)
+    __table_args__ = (
+        UniqueConstraint("course_id", "module_id", name="uq_course_module"),
+    )

--- a/backend/models/group.py
+++ b/backend/models/group.py
@@ -11,7 +11,6 @@ from sqlalchemy import (
     Integer,
     String,
     Text,
-    UniqueConstraint,
 )
 from sqlalchemy.orm import relationship
 
@@ -40,25 +39,4 @@ class Group(Base):
     )
 
 
-class UserGroup(Base):
-    """
-    Many-to-many relationship between users and groups.
-    Represents group membership.
-    """
-
-    __tablename__ = "user_groups"
-
-    id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
-    group_id = Column(Integer, ForeignKey("groups.id"), nullable=False, index=True)
-    role = Column(
-        String(20), nullable=False, default="member", index=True
-    )  # 'member', 'moderator', or 'owner'
-    joined_at = Column(TIMESTAMP, default=datetime.utcnow, nullable=False)
-
-    # Relationships
-    user = relationship("User", backref="group_memberships")
-    group = relationship("Group", back_populates="members")
-
-    # Ensure a user can only be in a group once
-    __table_args__ = (UniqueConstraint("user_id", "group_id", name="uq_user_group"),)
+# # Moved UserGroup to its own file, to follow the file scheme of everything else

--- a/backend/models/module.py
+++ b/backend/models/module.py
@@ -1,0 +1,26 @@
+"""
+Role model for modules
+"""
+
+from datetime import datetime
+
+from sqlalchemy import TIMESTAMP, Column, Integer, String, Text
+
+from .base import Base
+
+
+class Module(Base):
+    __tablename__ = "modules"
+
+    # Columns
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String(200), nullable=False, index=True)
+    description = Column(Text, nullable=True)
+    created_at = Column(TIMESTAMP, default=datetime.utcnow, nullable=False)
+    updated_at = Column(
+        TIMESTAMP, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+    color = Column(String(200))
+
+    # Note: Relationships to Course and Post will be handled in the association tables
+    # Relationships to users will be handled in ...

--- a/backend/models/module_post.py
+++ b/backend/models/module_post.py
@@ -1,0 +1,50 @@
+"""
+ModulePost model for many-to-many relationship between modules and posts
+"""
+
+from datetime import date, datetime
+
+from sqlalchemy import (
+    TIMESTAMP,
+    Column,
+    Date,
+    ForeignKey,
+    Integer,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import relationship
+
+from .base import Base
+
+
+class ModulePost(Base):
+    """
+    Many-to-many relationship between modules and posts.
+    Represents the modules inclulded in a course.
+    """
+
+    __tablename__ = "module_posts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    module_id = Column(
+        Integer,
+        ForeignKey("modules.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    post_id = Column(
+        Integer,
+        ForeignKey("posts.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    ordering = Column(Integer, nullable=False, default=0, index=True)
+    date_assigned = Column(Date, nullable=False, default=date.today)  # likely metadata
+    created_at = Column(TIMESTAMP, default=datetime.utcnow, nullable=False)
+
+    # Relationships
+    modlue = relationship("Module", backref="module_posts")
+    post = relationship("Post", backref="module_posts")
+
+    # Ensure a post can only be assigned to a module once
+    __table_args__ = (UniqueConstraint("module_id", "post_id", name="uq_module_post"),)

--- a/backend/models/post.py
+++ b/backend/models/post.py
@@ -1,0 +1,28 @@
+"""
+Post model for the higher-level broad description of a post
+"""
+
+from datetime import datetime
+
+from sqlalchemy import TIMESTAMP, Column, Integer, String, Text
+
+from .base import Base
+
+
+class Post(Base):
+    __tablename__ = "posts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String(200), nullable=False, index=True)
+    description = Column(Text, nullable=True)
+    created_at = Column(TIMESTAMP, default=datetime.utcnow, nullable=False)
+    updated_at = Column(
+        TIMESTAMP, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+
+    # Finer details of specific posts (refered to as "activities") to be handled
+    # in subtables representing the individual types
+
+    # Note: Relationship to Module and individal Activities will be hadled in
+    # their association tables
+    # Relationship to users will be handled in ...

--- a/backend/models/user_course.py
+++ b/backend/models/user_course.py
@@ -1,0 +1,52 @@
+"""
+UserCourse model for many-to-many relationship between users and courses
+"""
+
+from datetime import date
+
+from sqlalchemy import (
+    TIMESTAMP,
+    Boolean,
+    Column,
+    Date,
+    ForeignKey,
+    Integer,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import relationship
+
+from .base import Base
+
+
+class UserCourse(Base):
+    """
+    Many-to-many relationship between users and courses.
+    Represents the courses a user is enrolled in.
+    Provides a way to track courses a user has or has not completed
+    """
+
+    __tablename__ = "user_courses"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    course_id = Column(
+        Integer,
+        ForeignKey("courses.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    completed = Column(Boolean, default=False)
+    date_assigned = Column(Date, nullable=False, default=date.today)
+    completed_at = Column(TIMESTAMP)
+
+    # Relationships
+    user = relationship("User", backref="user_courses")
+    course = relationship("Course", backref="user_courses")
+
+    # Ensure a user can only be assigned to a course once
+    __table_args__ = (UniqueConstraint("user_id", "course_id", name="uq_user_course"),)

--- a/backend/models/user_group.py
+++ b/backend/models/user_group.py
@@ -1,0 +1,41 @@
+"""
+UserGroup model to show the users in a group
+"""
+
+from datetime import datetime
+
+from sqlalchemy import (
+    TIMESTAMP,
+    Column,
+    ForeignKey,
+    Integer,
+    String,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import relationship
+
+from .base import Base
+
+
+class UserGroup(Base):
+    """
+    Many-to-many relationship between users and groups.
+    Represents group membership.
+    """
+
+    __tablename__ = "user_groups"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    group_id = Column(Integer, ForeignKey("groups.id"), nullable=False, index=True)
+    role = Column(
+        String(20), nullable=False, default="member", index=True
+    )  # 'member', 'moderator', or 'owner'
+    joined_at = Column(TIMESTAMP, default=datetime.utcnow, nullable=False)
+
+    # Relationships
+    user = relationship("User", backref="group_memberships")
+    group = relationship("Group", back_populates="members")
+
+    # Ensure a user can only be in a group once
+    __table_args__ = (UniqueConstraint("user_id", "group_id", name="uq_user_group"),)

--- a/backend/models/user_modules.py
+++ b/backend/models/user_modules.py
@@ -1,0 +1,52 @@
+"""
+UserModule model for many-to-many relationship between users and modules
+"""
+
+from datetime import date
+
+from sqlalchemy import (
+    TIMESTAMP,
+    Boolean,
+    Column,
+    Date,
+    ForeignKey,
+    Integer,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import relationship
+
+from .base import Base
+
+
+class UserModule(Base):
+    """
+    Many-to-many relationship between users and modules.
+    Represents the modules a user is enrolled in.
+    Provides a way to track modules a user has or has not completed
+    """
+
+    __tablename__ = "user_modules"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    module_id = Column(
+        Integer,
+        ForeignKey("modules.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    completed = Column(Boolean, default=False)
+    date_assigned = Column(Date, nullable=False, default=date.today)
+    completed_at = Column(TIMESTAMP)
+
+    # Relationships
+    user = relationship("User", backref="user_modules")
+    module = relationship("Module", backref="user_modules")
+
+    # Ensure a user can only be assigned to a module once
+    __table_args__ = (UniqueConstraint("user_id", "module_id", name="uq_user_module"),)

--- a/backend/models/user_posts.py
+++ b/backend/models/user_posts.py
@@ -1,0 +1,52 @@
+"""
+UserCourse model for many-to-many relationship between users and posts
+"""
+
+from datetime import date
+
+from sqlalchemy import (
+    TIMESTAMP,
+    Boolean,
+    Column,
+    Date,
+    ForeignKey,
+    Integer,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import relationship
+
+from .base import Base
+
+
+class UserPost(Base):
+    """
+    Many-to-many relationship between users and posts.
+    Represents the posts a user is enrolled in.
+    Provides a way to track posts a user has or has not completed
+    """
+
+    __tablename__ = "user_posts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    post_id = Column(
+        Integer,
+        ForeignKey("posts.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    completed = Column(Boolean, default=False)
+    date_assigned = Column(Date, nullable=False, default=date.today)
+    completed_at = Column(TIMESTAMP)
+
+    # Relationships
+    user = relationship("User", backref="user_posts")
+    post = relationship("Post", backref="user_posts")
+
+    # Ensure a user can only be assigned to a post once
+    __table_args__ = (UniqueConstraint("user_id", "post_id", name="uq_user_post"),)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -249,7 +249,7 @@ async def test_group_accessible_by_regular(test_db, admin_user, regular_user):
         from sqlalchemy.orm import joinedload
 
         from models import Group
-        from models.group import UserGroup
+        from models.user_group import UserGroup
 
         # Create group
         group = Group(


### PR DESCRIPTION
Note on file naming conventions: File names in `/backend/models` are all lowercase and singular. Class names in those files are all singular and camel case, with the first letter capitalized. Table names within the classes are all snake case and **plural**.
## Added Models
Added the following models in accordance with our database design.
- modules
- posts
- course_modules
- module_posts
- user_courses
- user_modules
- user_posts

**Note:** We didn't actually define how we planned to represent the "activities." This needs to be a discussion. "Activities" have not been added to the models.


**Note II:** All the relationship names are singular, and this may be misleading depending on how they behave (giving back multiple things). The relationships look like this:
`course = relationship("Course", backref="course_groups")` <-- course_groups is the name of the table
Defining a relationship called "course" that when called, `course_groups.course` will get the courses associated with the current group (at least this is what I believe will happen, I could be wrong). I tried to model it after the existing M:M association table, `course_groups.py`.


## Moved `UserGroup` to its own File
This table was originally nested inside the `group.py` file, which made it difficult to find. Given that we have a lot of association tables for the M:M relationships, I moved it to its own file to match the flow of the files.

This also required a small change in `/backend/tests/conftest.py` to update the reference to UserGroup

## Updated the `/backend/models/__init__.py` File
Added all of the new files to the list of imports here. 