### PR TITLE
Post and Module Schemas created

### DIFF
--- a/backend/models/module_post.py
+++ b/backend/models/module_post.py
@@ -43,7 +43,7 @@ class ModulePost(Base):
     created_at = Column(TIMESTAMP, default=datetime.utcnow, nullable=False)
 
     # Relationships
-    modlue = relationship("Module", backref="module_posts")
+    module = relationship("Module", backref="module_posts")
     post = relationship("Post", backref="module_posts")
 
     # Ensure a post can only be assigned to a module once

--- a/backend/schemas/module.py
+++ b/backend/schemas/module.py
@@ -1,0 +1,51 @@
+"""
+Module Pydantic schemas for request/response validation
+"""
+
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict
+
+class ModuleBase(BaseModel):
+    """Base schema with common module fields"""
+
+    title: str
+    description: Optional[str] = None
+
+class ModuleCreate(ModuleBase):
+    """Schema for creating a new module"""
+
+    pass
+
+class ModuleUpdate(BaseModel):
+    """Schema for updating a module"""
+
+    title: Optional[str] = None
+    description: Optional[str] = None
+
+class ModuleResponse(ModuleBase):
+    """Module response schema"""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class PostInModule(BaseModel):
+    """Post information included in module""" 
+    
+    model_config = ConfigDict(from_attributes=True)
+
+    post_id: int
+    post_title: str
+    post_description: Optional[str]
+
+class ModuleDetailResponse(ModuleResponse):
+    """Module detail response schema with posts"""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    posts: List[PostInModule] = []

--- a/backend/schemas/module.py
+++ b/backend/schemas/module.py
@@ -7,22 +7,26 @@ from typing import List, Optional
 
 from pydantic import BaseModel, ConfigDict
 
+
 class ModuleBase(BaseModel):
     """Base schema with common module fields"""
 
     title: str
     description: Optional[str] = None
 
+
 class ModuleCreate(ModuleBase):
     """Schema for creating a new module"""
 
     pass
+
 
 class ModuleUpdate(BaseModel):
     """Schema for updating a module"""
 
     title: Optional[str] = None
     description: Optional[str] = None
+
 
 class ModuleResponse(ModuleBase):
     """Module response schema"""
@@ -35,13 +39,14 @@ class ModuleResponse(ModuleBase):
 
 
 class PostInModule(BaseModel):
-    """Post information included in module""" 
-    
+    """Post information included in module"""
+
     model_config = ConfigDict(from_attributes=True)
 
     post_id: int
     post_title: str
     post_description: Optional[str]
+
 
 class ModuleDetailResponse(ModuleResponse):
     """Module detail response schema with posts"""

--- a/backend/schemas/post.py
+++ b/backend/schemas/post.py
@@ -1,0 +1,51 @@
+"""
+Post Pydantic schemas for request/response validation
+"""
+
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict
+
+class PostBase(BaseModel):
+    """Base schema with common post fields"""
+
+    title: str
+    description: Optional[str] = None
+
+class PostCreate(PostBase):
+    """Schema for creating a new post"""
+
+    pass
+
+class PostUpdate(BaseModel):
+    """Schema for updating a post"""
+
+    title: Optional[str] = None
+    description: Optional[str] = None
+
+class PostResponse(PostBase):
+    """Post response schema"""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class ActivityInModule(BaseModel):
+    """Activity information included in module""" 
+    
+    model_config = ConfigDict(from_attributes=True)
+
+    post_id: int
+    post_title: str
+    post_description: Optional[str]
+
+class PostDetailResponse(PostResponse):
+    """Post detail response schema with activities"""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    activities: List[ActivityInModule] = []

--- a/backend/schemas/post.py
+++ b/backend/schemas/post.py
@@ -7,22 +7,26 @@ from typing import List, Optional
 
 from pydantic import BaseModel, ConfigDict
 
+
 class PostBase(BaseModel):
     """Base schema with common post fields"""
 
     title: str
     description: Optional[str] = None
 
+
 class PostCreate(PostBase):
     """Schema for creating a new post"""
 
     pass
+
 
 class PostUpdate(BaseModel):
     """Schema for updating a post"""
 
     title: Optional[str] = None
     description: Optional[str] = None
+
 
 class PostResponse(PostBase):
     """Post response schema"""
@@ -35,13 +39,14 @@ class PostResponse(PostBase):
 
 
 class ActivityInModule(BaseModel):
-    """Activity information included in module""" 
-    
+    """Activity information included in module"""
+
     model_config = ConfigDict(from_attributes=True)
 
     post_id: int
     post_title: str
     post_description: Optional[str]
+
 
 class PostDetailResponse(PostResponse):
     """Post detail response schema with activities"""


### PR DESCRIPTION
## Added Schemas
I added schemas for module and post tables. The schemas cover 
- base
- response
- update
- create
- detailed response (showing all the posts in module)
- the next table within the current table (post in module or activity in post)

## Other changes
- I changed one of the variable names in module_post.py because module was misspelled. 
- Please let me know if any additional schemas are needed. This is all I could think of

