### PR TITLE
Person 2: modules added to course detail page

### DIFF
--- a/ui/src/pages/courses/CourseDetailPage.tsx
+++ b/ui/src/pages/courses/CourseDetailPage.tsx
@@ -1,16 +1,19 @@
 import { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import { useDisclosure } from '@mantine/hooks';
-import { IconEdit } from '@tabler/icons-react';
+import { IconEdit, IconBook } from '@tabler/icons-react';
 import { useAuth } from '../../contexts/AuthContext';
 import { getCourse, patchCourse } from '../../utils/api';
 import AdminPageLayout from '../../components/layout/AdminPageLayout';
 import EditCourseModal from '../../components/courses/EditCourseModal';
 import { usePageState } from '../../hooks/usePageState';
-import type { CourseUpdate, CourseDetail } from '../../types/api';
+import type { CourseUpdate, CourseDetail, CourseModule } from '../../types/api';
+import { designTokens } from '../../designTokens';
+import { Stack, Text, Group, Button, Title, Card, Box } from '@mantine/core';
 
 export default function CourseDetailPage() {
     const { courseId } = useParams<{ courseId: string }>();
+    const navigate = useNavigate();
     const { API_URL, userInfo } = useAuth();
     const [editModalOpened, { open: openEditModal, close: closeEditModal }] =
         useDisclosure(false);
@@ -22,6 +25,9 @@ export default function CourseDetailPage() {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
 
+    // Form state variables for modules
+    const [modules, setModules] = useState<CourseModule[]>([]);
+    const [modulesLoading, setModulesLoading] = useState(false);
     // Check if user can edit (admin only)
     const canEdit = userInfo?.role?.name === 'admin';
 
@@ -44,6 +50,7 @@ export default function CourseDetailPage() {
     useEffect(() => {
         if (courseId) {
             fetchCourse();
+            fetchCourseModules();
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [courseId]);
@@ -56,6 +63,18 @@ export default function CourseDetailPage() {
         }
     }, [course]);
 
+    async function fetchCourseModules() {
+        if (!courseId) return;
+        setModulesLoading(true);
+        try {
+            const data = await getCourse(Number(courseId), API_URL);
+            setModules(data.modules);
+        } catch (err) {
+            console.error('Error fetching course modules:', err);
+        } finally {
+            setModulesLoading(false);
+        }
+    }
     function handleEditCourse() {
         if (course) {
             setCourseTitle(course.title);
@@ -128,12 +147,122 @@ export default function CourseDetailPage() {
             menuItems={menuItems}
             content={
                 <>
+                    {/* Modules Section */}
                     <div>
-                        <p>
-                            Modules functionality will be implemented by
-                            students.
-                        </p>
-                        <p>This course currently has no modules.</p>
+                        <Group justify="space-between" gap="sm" align="center">
+                            <Title order={2} mb="md">
+                                Modules
+                            </Title>
+
+                            {canEdit && (
+                                <Button
+                                    variant="filled"
+                                    color="teal"
+                                    onClick={() =>
+                                        navigate(
+                                            `/dashboard/courses/${course.id}/modules/new`
+                                        )
+                                    }
+                                    style={{
+                                        backgroundColor:
+                                            designTokens.app.primary,
+                                        color: designTokens.surface.white,
+                                    }}
+                                >
+                                    Create Module
+                                </Button>
+                            )}
+                        </Group>
+
+                        {modulesLoading ? (
+                            <Text>Loading modules...</Text>
+                        ) : modules.length === 0 ? (
+                            <Text c="dimmed" mb="md">
+                                There are no modules in this course.
+                            </Text>
+                        ) : (
+                            <Stack gap="sm">
+                                {modules.map((module) => (
+                                    <Card
+                                        key={module.module_id}
+                                        shadow="sm"
+                                        padding={0}
+                                        radius="md"
+                                        withBorder
+                                        style={{
+                                            cursor: 'pointer',
+                                            overflow: 'hidden',
+                                        }}
+                                        onClick={() =>
+                                            navigate(
+                                                `/dashboard/courses/${course.id}/modules/${module.module_id}`
+                                            )
+                                        }
+                                        onKeyDown={(e) => {
+                                            if (
+                                                e.key === 'Enter' ||
+                                                e.key === ' '
+                                            ) {
+                                                e.preventDefault();
+                                                navigate(
+                                                    `/dashboard/courses/${course.id}/modules/${module.module_id}`
+                                                );
+                                            }
+                                        }}
+                                        tabIndex={0}
+                                        role="button"
+                                    >
+                                        <Group
+                                            gap={0}
+                                            align="stretch"
+                                            style={{ minHeight: '100%' }}
+                                        >
+                                            <Box
+                                                style={{
+                                                    width: '120px',
+                                                    minHeight: '100%',
+                                                    backgroundColor:
+                                                        designTokens
+                                                            .moduleColors
+                                                            .darkBlue,
+                                                    display: 'flex',
+                                                    alignItems: 'center',
+                                                    justifyContent: 'center',
+                                                    flexShrink: 0,
+                                                }}
+                                            >
+                                                <IconBook
+                                                    size={48}
+                                                    style={{
+                                                        color: designTokens
+                                                            .surface.white,
+                                                    }}
+                                                />
+                                            </Box>
+                                            <Stack
+                                                gap="sm"
+                                                p="md"
+                                                style={{
+                                                    flex: 1,
+                                                    minHeight: '100%',
+                                                }}
+                                            >
+                                                <Text fw={600} size="md">
+                                                    {module.module_title}
+                                                </Text>
+                                                {module.module_description && (
+                                                    <Text c="dimmed" size="sm">
+                                                        {
+                                                            module.module_description
+                                                        }
+                                                    </Text>
+                                                )}
+                                            </Stack>
+                                        </Group>
+                                    </Card>
+                                ))}
+                            </Stack>
+                        )}
                     </div>
 
                     {/* Edit Course Modal */}


### PR DESCRIPTION
I modified the file `tma-starter-app/ui/src/pages/courses/CourseDetailPage.tsx` and made the following changes:
- add a modules section that lists all the modules within a course
- added a "create module" button that redirects the user to the create module page
- allowed each listed module to be clickable so that it navigates to the module detail page
- the page should also handle the following UI states: loading, error, empty, success

**Things to look for**
- added imports for mantine as well as the types and functions created by Connor
- added state variables for modules
- a fetchCourseModules function
- the modules section in the return
- note that a lot of the formatting is modeled after the group detail page seen in `tma-starter-app/ui/src/pages/groups/GroupDetailPage.tsx`
- Closes #46