### PR TITLE
Module Creation: Color Field

### DIFF
--- a/backend/routes/module.py
+++ b/backend/routes/module.py
@@ -178,6 +178,7 @@ async def create_module(
             description=(
                 module_data.description.strip() if module_data.description else None
             ),
+            color=(module_data.color.strip() if module_data.color else None),
         )
 
         db.add(new_module)
@@ -209,7 +210,7 @@ async def create_module(
             "description": new_module.description,
             "created_at": new_module.created_at,
             "updated_at": new_module.updated_at,
-            # add color field
+            "color": new_module.color,
         }
     except Exception as e:
         await db.rollback()

--- a/backend/schemas/module.py
+++ b/backend/schemas/module.py
@@ -13,6 +13,7 @@ class ModuleBase(BaseModel):
 
     title: str
     description: Optional[str] = None
+    color: Optional[str] = None
 
 
 class ModuleCreate(ModuleBase):

--- a/backend/tests/test_modules.py
+++ b/backend/tests/test_modules.py
@@ -203,7 +203,13 @@ async def test_create_module_success_admin_201(client: AsyncClient, auth_headers
     """Admin can POST /api/modules with valid data"""
     resp = await client.post(
         "/api/modules",
-        json={"module_data": {"title": "Test Module", "description": "test"}},
+        json={
+            "module_data": {
+                "title": "Test Module",
+                "description": "test",
+                "color": "#0000FF",
+            }
+        },
         headers=auth_headers,
     )
     assert resp.status_code == 201, resp.text
@@ -211,6 +217,7 @@ async def test_create_module_success_admin_201(client: AsyncClient, auth_headers
     assert_module_shape(data)
     assert data["title"] == "Test Module"
     assert data["description"] == "test"
+    assert data["color"] == "#0000FF"
 
 
 # PATCH /api/modules/{id} (update module)

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -159,6 +159,7 @@ export interface Module {
 export interface ModuleCreate {
     title: string;
     description?: string | null;
+    color?: string | null;
 }
 
 export interface ModuleUpdate {

--- a/ui/src/utils/api.ts
+++ b/ui/src/utils/api.ts
@@ -521,7 +521,7 @@ export async function getModule(
 
 /**
  * Create a new module
- * @param moduleData - Module data (title, description)
+ * @param moduleData - Module data (title, description, color)
  * @param apiUrl - Base API URL
  * @returns Created module object
  */


### PR DESCRIPTION
I added a field for module color in the following places:

- The ModuleBase schema in `backend/schemas/module.py`
- The JSON returned by the create_module route in `backend/routes/module.py`
- The test_create_module_success_admin_201 test in `backend/tests/test_modules.py`
- The ModuleCreate type in `ui/src/types/api.ts`
- The comment for the createModule API function in `ui/src/types/api.ts`

**Note**: The color field is still not used in most routes - this PR is purely intended to make it possible for the frontend to create modules with a specified color and add them to the db. For the moment, color cannot be updated nor accessed.