### PR TITLE
UPDATE Module detail + Edit 

### DIFF
--- a/ui/src/components/courses/EditModuleModal.tsx
+++ b/ui/src/components/courses/EditModuleModal.tsx
@@ -1,0 +1,80 @@
+import {
+    Modal,
+    Stack,
+    TextInput,
+    Textarea,
+    Group,
+    Button,
+} from '@mantine/core';
+
+interface EditModuleModalProps {
+    opened: boolean;
+    onClose: () => void;
+    moduleTitle: string;
+    moduleDescription: string;
+    onTitleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    onDescriptionChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+    onSubmit: (e: React.FormEvent) => void;
+    loading: boolean;
+    // File upload props (optional - for future implementation by students)
+    selectedFile?: File | null;
+    onFileChange?: (file: File | null) => void;
+    onRemoveImage?: () => void;
+    isRemoving?: boolean;
+    currentFileUrl?: string | null;
+    currentFileName?: string | null;
+}
+
+/**
+ * Modal for editing module details
+ * Note: File upload functionality will be implemented by students
+ */
+export default function EditModuleModal({
+    opened,
+    onClose,
+    moduleTitle,
+    moduleDescription,
+    onTitleChange,
+    onDescriptionChange,
+    onSubmit,
+    loading,
+}: EditModuleModalProps) {
+    return (
+        <Modal opened={opened} onClose={onClose} title="Edit Module" centered>
+            <form onSubmit={onSubmit}>
+                <Stack gap="md">
+                    <TextInput
+                        label="Module Title"
+                        placeholder="Enter module title"
+                        value={moduleTitle}
+                        onChange={onTitleChange}
+                        required
+                        disabled={loading}
+                        autoFocus
+                    />
+                    <Textarea
+                        label="Description"
+                        placeholder="Enter module description (optional)"
+                        value={moduleDescription}
+                        onChange={onDescriptionChange}
+                        disabled={loading}
+                        rows={4}
+                    />
+                    {/* File upload functionality will be implemented by students */}
+                    <Group justify="flex-end">
+                        <Button
+                            variant="subtle"
+                            onClick={onClose}
+                            disabled={loading}
+                        >
+                            Cancel
+                        </Button>
+                        <Button type="submit" loading={loading}>
+                            Update Module
+                        </Button>
+                    </Group>
+                </Stack>
+            </form>
+        </Modal>
+    );
+}

--- a/ui/src/pages/courses/ModuleDetailPage.tsx
+++ b/ui/src/pages/courses/ModuleDetailPage.tsx
@@ -1,3 +1,186 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useDisclosure } from '@mantine/hooks';
+import { getModule, patchModule } from '../../utils/api';
+import AdminPageLayout from '../../components/layout/AdminPageLayout';
+import { IconEdit } from '@tabler/icons-react';
+import { Group, Button, Title } from '@mantine/core';
+import { designTokens } from '../../designTokens';
+import EditModuleModal from '../../components/courses/EditModuleModal';
+import type { ModuleUpdate, ModuleDetail } from '../../types/api';
+import { usePageState } from '../../hooks/usePageState';
+import { useAuth } from '../../contexts/AuthContext';
+
 export default function ModuleDetailPage() {
-    return <></>;
+    const { moduleId } = useParams<{ moduleId: string }>();
+    const { API_URL, userInfo } = useAuth();
+    const navigate = useNavigate();
+    const { courseId } = useParams<{ courseId: string }>();
+    const [editModalOpened, { open: openEditModal, close: closeEditModal }] =
+        useDisclosure(false);
+
+    // Form state for module edit
+    const [moduleTitle, setModuleTitle] = useState('');
+    const [moduleDescription, setModuleDescription] = useState('');
+    const [module, setModule] = useState<ModuleDetail | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    // Check if user can edit (admin only)
+    const canEdit = userInfo?.role?.name === 'admin';
+
+    async function fetchModule() {
+        if (!moduleId) return;
+        setLoading(true);
+        setError(null);
+        try {
+            const moduleData = await getModule(Number(moduleId), API_URL);
+            setModule(moduleData);
+        } catch (err) {
+            const errorMessage =
+                err instanceof Error ? err.message : 'Unknown error';
+            setError(errorMessage);
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    useEffect(() => {
+        if (moduleId) {
+            fetchModule();
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [moduleId]);
+
+    // Initialize form state when module loads
+    useEffect(() => {
+        if (module) {
+            setModuleTitle(module.title);
+            setModuleDescription(module.description || '');
+        }
+    }, [module]);
+
+    function handleEditModule() {
+        if (module) {
+            setModuleTitle(module.title);
+            setModuleDescription(module.description || '');
+            openEditModal();
+        }
+    }
+
+    async function handleUpdateModule(e: React.FormEvent) {
+        e.preventDefault();
+        if (!moduleId) return;
+        setLoading(true);
+        setError(null);
+
+        try {
+            const updateData: ModuleUpdate = {
+                title: moduleTitle.trim(),
+                description: moduleDescription.trim() || null,
+            };
+
+            await patchModule(Number(moduleId), updateData, API_URL);
+            closeEditModal();
+            await fetchModule();
+        } catch (err) {
+            const errorMessage =
+                err instanceof Error ? err.message : 'Unknown error';
+            setError(errorMessage);
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    const pageState = usePageState({
+        data: module,
+        loading,
+        error,
+        notFoundMessage: 'Module Not Found',
+    });
+
+    if (!pageState.shouldRenderContent) {
+        return pageState.component;
+    }
+
+    if (!module) {
+        return null;
+    }
+
+    //dashboard/courses/:courseId/modules/:moduleId
+    const breadcrumbs = [
+        { title: 'Dashboard', href: '/dashboard/courses' },
+        { title: 'Courses', href: '/dashboard/courses' },
+        {
+            title: 'Modules',
+            href: '/dashboard/courses/${courseId}/modules/${moduleId}',
+        },
+        { title: module.title, href: '#' },
+    ];
+
+    const menuItems = canEdit
+        ? [
+              {
+                  label: 'Edit Module',
+                  icon: <IconEdit size={16} />,
+                  onClick: handleEditModule,
+              },
+          ]
+        : undefined;
+
+    return (
+        <AdminPageLayout
+            breadcrumbs={breadcrumbs}
+            title={module.title}
+            description={module.description || undefined}
+            menuItems={menuItems}
+            content={
+                <>
+                    {/* Modules Section */}
+                    <div>
+                        <Group justify="space-between" gap="sm" align="center">
+                            <Title order={2} mb="md">
+                                Modules
+                            </Title>
+                            {canEdit && (
+                                <Button
+                                    variant="filled"
+                                    color="teal"
+                                    onClick={() =>
+                                        navigate(
+                                            `/dashboard/courses/${courseId}/modules/${moduleId}`
+                                        )
+                                    }
+                                    style={{
+                                        backgroundColor:
+                                            designTokens.app.primary,
+                                        color: designTokens.surface.white,
+                                    }}
+                                >
+                                    Update Module
+                                </Button>
+                            )}
+                        </Group>
+                    </div>
+                    {/* Edit Course Modal */}
+                    {canEdit && (
+                        <EditModuleModal
+                            opened={editModalOpened}
+                            onClose={closeEditModal}
+                            moduleTitle={moduleTitle}
+                            moduleDescription={moduleDescription}
+                            onTitleChange={(
+                                e: React.ChangeEvent<HTMLInputElement>
+                            ) => setModuleTitle(e.currentTarget.value)}
+                            onDescriptionChange={(
+                                e: React.ChangeEvent<HTMLTextAreaElement>
+                            ) => setModuleDescription(e.currentTarget.value)}
+                            onSubmit={handleUpdateModule}
+                            loading={loading}
+                        />
+                    )}
+                </>
+            }
+        />
+    );
 }


### PR DESCRIPTION
Updated ui/src/pages/courses/ModuleDetailPage.tsx and added ui/src/components/courses/EditModuleModal.tsx for modal for editing.

- Built the Module detail page
- Fetch and display one module (loading/error/success states).
- Add an Edit action (modal or page) and wire it to the update endpoint.
- Refresh the displayed module data after a successful update.

Closes UPDATE Module detail + Edit #45 

I'm not sure if I've covered everything. Please let me know if there's an error or something is missing. 