### PR TITLE
Fix patchModule Helper Function

### DIFF
--- a/ui/src/utils/api.ts
+++ b/ui/src/utils/api.ts
@@ -575,7 +575,10 @@ export async function patchModule(
     const response = await fetch(`${apiUrl}/modules/${moduleId}`, {
         method: 'PATCH',
         headers: getAuthHeaders(),
-        body: JSON.stringify(moduleData),
+        body: JSON.stringify({
+            module_data: moduleData,
+            module_posts: [],
+        }),
     });
     return handleResponse<Module>(response) as Promise<Module>;
 }


### PR DESCRIPTION
I changed the `patchModule` helper function on the frontend to match the route function `update_module` on the backend.