### PR TITLE
Fix get_course Route

### DIFF
--- a/backend/routes/courses.py
+++ b/backend/routes/courses.py
@@ -120,7 +120,8 @@ async def get_course(
                 "ordering": cm.ordering,
             }
             for cm in course.course_modules
-        ],
+        ]
+        or [],
     }
 
 


### PR DESCRIPTION
I changed the `get_course` route to still include a `modules` key even if the course doesn't have any modules. That way, the `CourseDetailPage` works for empty courses.