### PR TITLE
course and module detail page complete

### DIFF
--- a/backend/routes/module.py
+++ b/backend/routes/module.py
@@ -136,6 +136,22 @@ async def get_module(
             "description": module.description,
             "created_at": module.created_at,
             "updated_at": module.updated_at,
+            "posts": [
+                {
+                    "post_id": mp.post_id,
+                    "post_title": mp.post.title if mp.post else "",
+                    "post_type": mp.post.type if mp.post else None,
+                    "post_text": mp.post.text if mp.post else None,
+                    "post_image": mp.post.image if mp.post else None,
+                    "post_file_url": mp.post.file_url if mp.post else None,
+                    "post_file_name": mp.post.file_name if mp.post else None,
+                    "post_video_url": mp.post.video_url if mp.post else None,
+                    "post_video_name": mp.post.video_name if mp.post else None,
+                    "ordering": mp.ordering,
+                }
+                for mp in module.module_posts
+            ]
+            or [],
         }
         # only show modules a user is associated with if non-admin
     else:

--- a/mobile/app/(tabs)/courses/[id].tsx
+++ b/mobile/app/(tabs)/courses/[id].tsx
@@ -6,17 +6,20 @@ import {
     ActivityIndicator,
     Snackbar,
     Appbar,
+    useTheme,
 } from 'react-native-paper';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import ProtectedRoute from '../../../components/ProtectedRoute';
 import { getCourseDetail } from '../../../services/courses';
 import { CourseDetail, CourseModule } from '../../../types';
 import { designTokens } from '../../../theme';
+import ModuleCard from '../../../components/modules/ModuleCard';
 
 export default function CourseDetailScreen() {
     const { id } = useLocalSearchParams<{ id: string }>();
     const router = useRouter();
     const courseId = parseInt(id || '0', 10);
+    const theme = useTheme();
 
     const {
         data: course,
@@ -40,9 +43,16 @@ export default function CourseDetailScreen() {
 
     return (
         <ProtectedRoute>
-            <View style={styles.container}>
+            <View
+                style={[
+                    styles.container,
+                    { backgroundColor: theme.colors.background },
+                ]}
+            >
                 <Appbar.Header>
-                    <Appbar.BackAction onPress={() => router.back()} />
+                    <Appbar.BackAction
+                        onPress={() => router.push('/courses')}
+                    />
                     <Appbar.Content title={course?.title || 'Course'} />
                 </Appbar.Header>
 
@@ -111,77 +121,11 @@ export default function CourseDetailScreen() {
                                             ) => a.ordering - b.ordering
                                         )
                                         .map((module: CourseModule) => (
-                                            <Card
+                                            <ModuleCard
                                                 key={module.module_id}
-                                                style={styles.card}
-                                                mode="elevated"
-                                                onPress={() =>
-                                                    router.push(
-                                                        `/(tabs)/modules/${module.module_id}`
-                                                    )
-                                                }
-                                            >
-                                                <Card.Content
-                                                    style={{
-                                                        padding:
-                                                            designTokens.spacing
-                                                                .xl,
-                                                    }}
-                                                >
-                                                    <View
-                                                        style={
-                                                            styles.moduleHeader
-                                                        }
-                                                    >
-                                                        <View
-                                                            style={{
-                                                                flexDirection:
-                                                                    'row',
-                                                                alignItems:
-                                                                    'center',
-                                                                flex: 1,
-                                                            }}
-                                                        >
-                                                            {module.module_color && (
-                                                                <View
-                                                                    style={[
-                                                                        styles.colorIndicator,
-                                                                        {
-                                                                            backgroundColor:
-                                                                                module.module_color,
-                                                                        },
-                                                                    ]}
-                                                                />
-                                                            )}
-                                                            <Text
-                                                                variant="titleMedium"
-                                                                style={{
-                                                                    fontWeight:
-                                                                        '600',
-                                                                    flex: 1,
-                                                                }}
-                                                            >
-                                                                {
-                                                                    module.module_title
-                                                                }
-                                                            </Text>
-                                                        </View>
-                                                    </View>
-                                                    {module.module_description && (
-                                                        <Text
-                                                            variant="bodyMedium"
-                                                            style={
-                                                                styles.description
-                                                            }
-                                                            numberOfLines={2}
-                                                        >
-                                                            {
-                                                                module.module_description
-                                                            }
-                                                        </Text>
-                                                    )}
-                                                </Card.Content>
-                                            </Card>
+                                                module={module}
+                                                course={course}
+                                            />
                                         ))
                                 )}
                             </>

--- a/mobile/app/(tabs)/modules/[id].tsx
+++ b/mobile/app/(tabs)/modules/[id].tsx
@@ -1,41 +1,225 @@
-import { View, StyleSheet } from 'react-native';
-import { Text } from 'react-native-paper';
-import { Appbar } from 'react-native-paper';
-import { useRouter } from 'expo-router';
+import { View, StyleSheet, ScrollView, RefreshControl } from 'react-native';
+import { useQuery } from '@tanstack/react-query';
+import {
+    Card,
+    Snackbar,
+    Text,
+    ActivityIndicator,
+    Appbar,
+} from 'react-native-paper';
+import { useLocalSearchParams, useRouter } from 'expo-router';
 import ProtectedRoute from '../../../components/ProtectedRoute';
 import { designTokens } from '../../../theme';
+import { getModuleDetail } from '../../../services/modules';
+import { ModuleDetail, ModulePost } from '../../../types';
+import PostAttachment from '../../../components/posts/PostAttachment';
+import PostGeneric from '../../../components/posts/PostGeneric';
+import PostVideo from '../../../components/posts/PostVideo';
 
 export default function ModuleDetailScreen() {
+    const { id } = useLocalSearchParams<{ id: string }>();
     const router = useRouter();
+    const moduleId = parseInt(id || '0', 10);
+    const courseId = parseInt(
+        useLocalSearchParams<{ courseId: string }>().courseId || '0',
+        10
+    );
+
+    const {
+        data: module,
+        isLoading,
+        error,
+        refetch,
+        isRefetching,
+    } = useQuery<ModuleDetail>({
+        queryKey: ['moduleDetail', moduleId],
+        queryFn: () => getModuleDetail(moduleId),
+        enabled: Boolean(moduleId && moduleId > 0),
+    });
+
+    if (isLoading) {
+        return (
+            <View style={styles.center}>
+                <ActivityIndicator size="large" />
+            </View>
+        );
+    }
 
     return (
         <ProtectedRoute>
             <View style={styles.container}>
                 <Appbar.Header>
-                    <Appbar.BackAction onPress={() => router.back()} />
-                    <Appbar.Content title="Module" />
+                    <Appbar.BackAction
+                        onPress={() =>
+                            router.push(`/(tabs)/courses/${courseId}`)
+                        }
+                    />
+                    <Appbar.Content title={module?.title || 'Module'} />
                 </Appbar.Header>
-                <View style={styles.content}>
-                    <Text variant="headlineSmall" style={styles.message}>
-                        To Be Implemented
-                    </Text>
-                    <Text variant="bodyMedium" style={styles.subtitle}>
-                        Module functionality will be implemented by students.
-                    </Text>
-                </View>
+
+                <ScrollView
+                    refreshControl={
+                        <RefreshControl
+                            refreshing={isRefetching}
+                            onRefresh={() => refetch()}
+                        />
+                    }
+                >
+                    <View style={styles.content}>
+                        {error && (
+                            <Snackbar
+                                visible={Boolean(error)}
+                                onDismiss={() => {}}
+                                duration={4000}
+                            >
+                                Error loading module. Please try again.
+                            </Snackbar>
+                        )}
+
+                        {module && (
+                            <>
+                                {module.description && (
+                                    <Card style={styles.card}>
+                                        <Card.Content>
+                                            <Text variant="bodyLarge">
+                                                {module.description}
+                                            </Text>
+                                        </Card.Content>
+                                    </Card>
+                                )}
+                                <Text
+                                    variant="titleLarge"
+                                    style={styles.sectionTitle}
+                                >
+                                    Posts
+                                </Text>
+
+                                {!module.posts || module.posts.length === 0 ? (
+                                    <Card style={styles.card} mode="outlined">
+                                        <Card.Content
+                                            style={{
+                                                padding:
+                                                    designTokens.spacing.xxl,
+                                                alignItems: 'center',
+                                            }}
+                                        >
+                                            <Text
+                                                variant="bodyMedium"
+                                                style={{ opacity: 0.7 }}
+                                            >
+                                                No posts in this module.
+                                            </Text>
+                                        </Card.Content>
+                                    </Card>
+                                ) : (
+                                    module.posts
+                                        .sort(
+                                            (a: ModulePost, b: ModulePost) =>
+                                                a.ordering - b.ordering
+                                        )
+                                        .map((mp: ModulePost) =>
+                                            // check if PostGeneric, PostAttachment, or PostVideo type and render accordingly
+
+                                            mp.post_type === 'attachment' ? (
+                                                <PostAttachment
+                                                    key={mp.post_id}
+                                                    post={{
+                                                        id: mp.post_id,
+                                                        title: mp.post_title,
+                                                        type: 'attachment',
+                                                        text:
+                                                            mp.post_text ??
+                                                            null,
+                                                        file_url:
+                                                            mp.post_file_url ??
+                                                            null,
+                                                        file_name:
+                                                            mp.post_file_name ??
+                                                            null,
+                                                    }}
+                                                />
+                                            ) : mp.post_type === 'video' ? (
+                                                <PostVideo
+                                                    key={mp.post_id}
+                                                    post={{
+                                                        id: mp.post_id,
+                                                        title: mp.post_title,
+                                                        type: 'video',
+                                                        text:
+                                                            mp.post_text ??
+                                                            null,
+                                                        video_url:
+                                                            mp.post_video_url ??
+                                                            null,
+                                                        video_name:
+                                                            mp.post_video_name ??
+                                                            null,
+                                                    }}
+                                                />
+                                            ) : (
+                                                <PostGeneric
+                                                    key={mp.post_id}
+                                                    post={{
+                                                        id: mp.post_id,
+                                                        title: mp.post_title,
+                                                        type: 'generic',
+                                                        text:
+                                                            mp.post_text ??
+                                                            null,
+                                                        image:
+                                                            mp.post_image ??
+                                                            null,
+                                                    }}
+                                                />
+                                            )
+                                        )
+                                )}
+                            </>
+                        )}
+                    </View>
+                </ScrollView>
             </View>
         </ProtectedRoute>
     );
 }
 
 const styles = StyleSheet.create({
-    container: { flex: 1 },
+    container: {
+        flex: 1,
+    },
     content: {
+        padding: designTokens.spacing.xl,
+        paddingBottom: designTokens.spacing.xxxl,
+    },
+    center: {
         flex: 1,
         justifyContent: 'center',
         alignItems: 'center',
-        padding: designTokens.spacing.xl,
     },
-    message: { marginBottom: designTokens.spacing.sm },
-    subtitle: { opacity: 0.7, textAlign: 'center' },
+    card: {
+        marginBottom: designTokens.spacing.lg,
+        borderRadius: designTokens.borderRadius.lg,
+    },
+    sectionTitle: {
+        marginBottom: designTokens.spacing.lg,
+        marginTop: designTokens.spacing.sm,
+        fontWeight: '600',
+    },
+    moduleHeader: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        marginBottom: designTokens.spacing.sm,
+    },
+    colorIndicator: {
+        width: 20,
+        height: 20,
+        borderRadius: 10,
+        marginRight: designTokens.spacing.md,
+    },
+    description: {
+        marginTop: designTokens.spacing.sm,
+        opacity: 0.7,
+        lineHeight: 20,
+    },
 });

--- a/mobile/components/modules/ModuleCard.tsx
+++ b/mobile/components/modules/ModuleCard.tsx
@@ -1,0 +1,120 @@
+import { StyleSheet, View } from 'react-native';
+import { Card, Text } from 'react-native-paper';
+import type { CourseModule, Course } from '../../types/api.ts';
+import { designTokens } from '../../theme';
+import { useRouter } from 'expo-router';
+
+interface ModuleCardProps {
+    module: CourseModule;
+}
+
+interface CourseProps {
+    course: Course;
+}
+
+export default function ModuleCard({
+    module,
+    course,
+}: ModuleCardProps & CourseProps) {
+    const router = useRouter();
+
+    return (
+        <Card
+            key={module.module_id}
+            style={styles.card}
+            mode="elevated"
+            onPress={() =>
+                router.push({
+                    pathname: `/(tabs)/modules/${module.module_id}`,
+                    params: { courseId: course.id },
+                })
+            }
+        >
+            <Card.Content
+                style={{
+                    padding: designTokens.spacing.xl,
+                }}
+            >
+                <View style={styles.moduleHeader}>
+                    <View
+                        style={{
+                            flexDirection: 'row',
+                            alignItems: 'center',
+                            flex: 1,
+                        }}
+                    >
+                        {module.module_color && (
+                            <View
+                                style={[
+                                    styles.colorIndicator,
+                                    {
+                                        backgroundColor: module.module_color,
+                                    },
+                                ]}
+                            />
+                        )}
+                        <Text
+                            variant="titleMedium"
+                            style={{
+                                fontWeight: '600',
+                                flex: 1,
+                            }}
+                        >
+                            {module.module_title}
+                        </Text>
+                    </View>
+                </View>
+                {module.module_description && (
+                    <Text
+                        variant="bodyMedium"
+                        style={styles.description}
+                        numberOfLines={2}
+                    >
+                        {module.module_description}
+                    </Text>
+                )}
+            </Card.Content>
+        </Card>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+    },
+    content: {
+        padding: designTokens.spacing.xl,
+        paddingBottom: designTokens.spacing.xxxl,
+    },
+    center: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    card: {
+        marginBottom: designTokens.spacing.lg,
+        borderRadius: designTokens.borderRadius.lg,
+    },
+    sectionTitle: {
+        marginBottom: designTokens.spacing.lg,
+        marginTop: designTokens.spacing.sm,
+        fontWeight: '600',
+    },
+    moduleHeader: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        marginBottom: designTokens.spacing.sm,
+    },
+    colorIndicator: {
+        width: 20,
+        height: 20,
+        borderRadius: 10,
+        marginRight: designTokens.spacing.md,
+    },
+    description: {
+        marginTop: designTokens.spacing.sm,
+        opacity: 0.7,
+        lineHeight: 20,
+    },
+});

--- a/mobile/components/posts/PostAttachment.tsx
+++ b/mobile/components/posts/PostAttachment.tsx
@@ -1,0 +1,17 @@
+import { View } from 'react-native';
+import { Text } from 'react-native-paper';
+import type { PostAttachment } from '../../types/api.ts';
+
+interface PostAttachmentProps {
+    post: PostAttachment;
+}
+
+export default function PostAttachment({ post }: PostAttachmentProps) {
+    return (
+        <>
+            <View>
+                <Text>{post.title}</Text>
+            </View>
+        </>
+    );
+}

--- a/mobile/components/posts/PostGeneric.tsx
+++ b/mobile/components/posts/PostGeneric.tsx
@@ -1,0 +1,17 @@
+import { View } from 'react-native';
+import { Text } from 'react-native-paper';
+import type { PostGeneric } from '../../types/api.ts';
+
+interface PostGenericProps {
+    post: PostGeneric;
+}
+
+export default function PostGeneric({ post }: PostGenericProps) {
+    return (
+        <>
+            <View>
+                <Text>{post.title}</Text>
+            </View>
+        </>
+    );
+}

--- a/mobile/components/posts/PostVideo.tsx
+++ b/mobile/components/posts/PostVideo.tsx
@@ -1,0 +1,17 @@
+import { View } from 'react-native';
+import { Text } from 'react-native-paper';
+import type { PostVideo } from '../../types/api.ts';
+
+interface PostVideoProps {
+    post: PostVideo;
+}
+
+export default function PostVideo({ post }: PostVideoProps) {
+    return (
+        <>
+            <View>
+                <Text>{post.title}</Text>
+            </View>
+        </>
+    );
+}

--- a/mobile/types/api.ts
+++ b/mobile/types/api.ts
@@ -157,20 +157,22 @@ export interface ModuleDetail extends Module {
 export interface Post {
     id: number;
     title: string;
-    type?: string | null;
     text?: string | null;
 }
 
 export interface PostGeneric extends Post {
+    type: 'generic';
     image?: string | null;
 }
 
 export interface PostAttachment extends Post {
+    type: 'attachment';
     file_url?: string | null;
     file_name?: string | null;
 }
 
 export interface PostVideo extends Post {
+    type: 'video';
     video_url?: string | null;
     video_name?: string | null;
 }


### PR DESCRIPTION
In this PR, I implement the rest of the functionality required of Person 1. 
- Closes #62 

**Enhance Course Detail Screen `mobile/app/(tabs)/courses/[id].tsx`**
- there was already an implementation of a card to display each module so I just moved that code to a separate component file
- I made any necessary edits and then called the ModuleCard component in the Course Detail Screen
- I also adjusted the routing for when the back button is clicked so that it takes the user to the courses page instead of the home page

**Module Card Component**
- this was primarily based on the code that was originally in `mobile/app/(tabs)/courses/[id].tsx`
- note that for the routing I had to add a parameter so that the back button on the module detail page would return to the course detail page

**Module Detail Screen `mobile/app/(tabs)/modules/[id].tsx`**
- This was very similar to the Course Detail screen
- I had to make some adjustments to the `CourseModule`, `Post`, `PostGeneric`, `PostAttachment`, and `PostVideo` types to allow for me to adequately call the specific components
- I added a type to `PostGeneric`, `PostAttachment`, and `PostVideo`
- I added ordering to `Post`
- Additionally note that in order to implement functionality, I had to put in blank components for `PostGeneric`, `PostAttachment`, and `PostVideo`